### PR TITLE
✨ House 농장 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
@@ -1,0 +1,33 @@
+package com.smartfarm.chameleon.domain.house.api;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.smartfarm.chameleon.domain.house.application.HouseService;
+import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequestMapping("/house")
+@RestController
+public class HouseController {
+    
+    @Autowired
+    private HouseService houseService;
+
+    @GetMapping("/info")
+    @Operation(summary = "농장 정보 조회" , description = "키우는 작물, 주소를 조회하는 API")
+    public ResponseEntity<List<HouseInfoDTO>> read_house(@RequestHeader("Authorization") String access_token) {
+        return new ResponseEntity<>(houseService.read_house(access_token.substring(7)), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -1,0 +1,74 @@
+package com.smartfarm.chameleon.domain.house.application;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
+import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
+import com.smartfarm.chameleon.domain.house.dto.UserHouseDTO;
+import com.smartfarm.chameleon.global.jwt.JwtTokenProvider;
+import com.smartfarm.chameleon.global.toHouse.HttpHouse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class HouseService {
+
+    @Autowired
+    private HouseMapper houseMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private HttpHouse httpHouse;
+    
+    // 농장 정보 조회
+    public List<HouseInfoDTO> read_house(String access_token){
+
+        // 사용자 아이디
+        String user_id = jwtTokenProvider.getUserID(access_token);
+        // 사용자 index id 받아오기
+        int id = houseMapper.read_index(user_id);
+
+        // 사용자 index id로 농장 아이디, 농장 백엔드 주소 받아오기
+        List<UserHouseDTO> url_list = houseMapper.read_back_url(id);
+
+        // 결과를 담을 List
+        List<HouseInfoDTO> result = new ArrayList<>();
+
+        // 백엔드 요청
+        for(UserHouseDTO h : url_list){
+            String get_url = h.getHouse_back_url() + "/house/info";
+
+            // get 요청
+            JSONObject house_result = httpHouse.get_http_connection(get_url).get();
+
+            // 결과 생성
+            HouseInfoDTO info_result = new HouseInfoDTO();
+            info_result.setHouse_id(h.getHouse_id());
+            info_result.setHouse_name(h.getHouse_name());
+            info_result.setHouse_crop(house_result.get("house_crop").toString());
+            info_result.setHouse_add(house_result.get("house_add").toString());
+
+            log.info("농장 정보 조회 서비스 결과 : " + info_result.toString());
+
+            // 결과 리스트에 객체 추가
+            result.add(info_result);
+            
+        }
+
+        // 결과 출력
+        for(HouseInfoDTO h : result){
+            log.info(h.toString());
+        }
+
+        return result;
+        
+    }
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
@@ -1,0 +1,18 @@
+package com.smartfarm.chameleon.domain.house.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.smartfarm.chameleon.domain.house.dto.UserHouseDTO;
+
+@Mapper
+public interface HouseMapper {
+    
+    // 사용자 아이디로 사용자 index id 받아오기
+    public int read_index(String user_id);
+
+    // 사용자 index id로 농장 아이디, 농장 백엔드 주소 받아오기
+    public List<UserHouseDTO> read_back_url(int id);
+
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house/dto/HouseInfoDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dto/HouseInfoDTO.java
@@ -1,0 +1,19 @@
+package com.smartfarm.chameleon.domain.house.dto;
+
+import lombok.Data;
+
+@Data
+public class HouseInfoDTO {
+    
+    // 농장 아이디
+    private int house_id;
+
+    // 키우는 작물
+    private String house_crop;
+
+    // 농장 주소
+    private String house_add;
+
+    // 농장 이름
+    private String house_name;
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house/dto/UserHouseDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dto/UserHouseDTO.java
@@ -1,0 +1,21 @@
+package com.smartfarm.chameleon.domain.house.dto;
+
+import lombok.Data;
+
+@Data
+public class UserHouseDTO {
+
+    // 사용자 인덱스 아이디
+    private String id;
+
+    // 사용자 농장의 백엔드 주소
+    private String house_back_url;
+
+    // 사용자 농장 아이디
+    private int house_id;
+
+    // 사용자 농자 이름
+    private String house_name;
+
+    
+}

--- a/src/main/resources/mappers/HouseMapper.xml
+++ b/src/main/resources/mappers/HouseMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.smartfarm.chameleon.domain.house.dao.HouseMapper">
+
+    <!-- 사용자 아이디로 사용자 index id 받아오기 -->
+    <select id="read_index"
+        resultType="java.lang.Integer">
+
+        SELECT  id
+        FROM    user
+        WHERE   user_id = #{user_id}
+
+    </select>
+
+    <!-- 사용자 index id로 농장 아이디, 농장 백엔드 주소 받아오기 -->
+    <select id="read_back_url"
+        parameterType="java.lang.Integer"
+        resultType="com.smartfarm.chameleon.domain.house.dto.UserHouseDTO">
+
+        SELECT  id, house_id, house_name, house_back_url
+        FROM    house
+        WHERE   id=#{id}
+
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 개요
House 농장 정보 조회 기능 추가
- 토큰에 저장된 사용자 아이디로 사용자 index id 받아오기
- 사용자 index id로 회사 서버의 house 테이블에서 농장 아이디, 농장 이름, 농장 백엔드 주소 받아오기
→ List<UserHouseDTO> 
- 각각의 백엔드 주소에서 "/house/info" 추가해 농장 작물, 농장 주소 받아오기
- HouseInfoDTO객체에 농장 아이디, 이름 / 작물, 주소 저장하기
- 위의 과정을 반복해 List<HouseInfoDTO>로 반환

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 농장 정보 수정 기능
