### PR TITLE
✨ 농장 이름 리스트 조회와 농장 정보 수정 기능 추가

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
@@ -15,6 +15,11 @@ import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
 
 @Slf4j
 @RequestMapping("/house")
@@ -28,6 +33,18 @@ public class HouseController {
     @Operation(summary = "농장 정보 조회" , description = "키우는 작물, 주소를 조회하는 API")
     public ResponseEntity<List<HouseInfoDTO>> read_house(@RequestHeader("Authorization") String access_token) {
         return new ResponseEntity<>(houseService.read_house(access_token.substring(7)), HttpStatus.OK);
+    }
+
+    @GetMapping("/name_list")
+    @Operation(summary = "농장 이름 리스트 반환" , description = "농장 이름 리스트를 반환하는 API")
+    public ResponseEntity<List<HouseInfoDTO>> read_house_name_list(@RequestHeader("Authorization") String access_token) {
+        return new ResponseEntity<>(houseService.read_house_name_list(access_token.substring(7)), HttpStatus.OK);
+    }
+    
+    @PutMapping("/update")
+    @Operation(summary = "농장 정보 수정" , description = "농장 아이디로 농장 이름과 키우는 작물 수정하는 API")
+    public void update_house_name(@RequestHeader("Authorization") String access_token, @RequestBody HouseInfoDTO houseInfoDto ) {
+        houseService.update_house_name(access_token.substring(7), houseInfoDto );
     }
 
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -36,8 +36,8 @@ public class HouseService {
         // 사용자 index id 받아오기
         int id = houseMapper.read_index(user_id);
 
-        // 사용자 index id로 농장 아이디, 농장 백엔드 주소 받아오기
-        List<UserHouseDTO> url_list = houseMapper.read_back_url(id);
+        // 사용자 index id로 농장 아이디, 농장 이름, 농장 백엔드 주소 받아오기
+        List<UserHouseDTO> url_list = houseMapper.read_back_url_list(id);
 
         // 결과를 담을 List
         List<HouseInfoDTO> result = new ArrayList<>();
@@ -70,5 +70,30 @@ public class HouseService {
 
         return result;
         
+    }
+
+    // 사용자 index id로 사용자가 보유한 농장 이름 리스트 반환
+    public List<HouseInfoDTO> read_house_name_list(String access_token){
+
+        // 사용자 아이디
+        String user_id = jwtTokenProvider.getUserID(access_token);
+        // 사용자 index id 받아오기
+        int id = houseMapper.read_index(user_id);
+
+        return houseMapper.read_house_name_list(id);
+    }
+
+    // 농장 아이디로 농장 이름과 키우는 작물 수정
+    public void update_house_name(String access_token, HouseInfoDTO houseInfoDto){
+
+        // 농장 아이디로 농장 이름 변경
+        houseMapper.update_house_name(houseInfoDto);
+
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String put_url = houseMapper.read_back_url(houseInfoDto.getHouse_id()) + "/house/update";
+
+        // put 요청
+        httpHouse.put_http_connection(put_url, houseInfoDto);
+
     }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
 import com.smartfarm.chameleon.domain.house.dto.UserHouseDTO;
 
 @Mapper
@@ -13,6 +14,15 @@ public interface HouseMapper {
     public int read_index(String user_id);
 
     // 사용자 index id로 농장 아이디, 농장 백엔드 주소 받아오기
-    public List<UserHouseDTO> read_back_url(int id);
+    public List<UserHouseDTO> read_back_url_list(int id);
+
+    // 사용자 index id로 사용자가 보유한 농장 이름 리스트 반환
+    public List<HouseInfoDTO> read_house_name_list(int id);
+
+    // 농장 아이디로 농장 이름 변경
+    public void update_house_name(HouseInfoDTO houseInfoDto);
+
+    // 농장 아이디로 농장의 백엔드 주소 가져오기
+    public String read_back_url(int house_id);
 
 }

--- a/src/main/java/com/smartfarm/chameleon/global/toHouse/HttpHouse.java
+++ b/src/main/java/com/smartfarm/chameleon/global/toHouse/HttpHouse.java
@@ -1,6 +1,7 @@
 package com.smartfarm.chameleon.global.toHouse;
 
 import java.io.BufferedReader;
+import java.io.DataOutputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -10,12 +11,21 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 public class HttpHouse {
 
+    /**
+     * Get Http Connection
+     * 결과값을 JsonObject로 반환
+     * 
+     * @param get_url
+     * @return JsonObject
+     */
     public Optional<JSONObject> get_http_connection(String get_url){
 
         try {
@@ -58,6 +68,51 @@ public class HttpHouse {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             return Optional.empty();
+        }
+
+    }
+
+    public void put_http_connection(String put_url, Object put_data){
+
+        try {
+
+            // connection 생성
+            URL url = new URL(put_url);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            conn.setDoOutput(true);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            try (DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+                // out.writeBytes(objectMapper.writeValueAsString(put_data));
+                out.write(objectMapper.writeValueAsString(put_data).getBytes("UTF-8"));
+                out.flush();
+            }
+
+            // 결과값 받아오기
+            BufferedReader rd;
+            if(conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream(), "UTF-8"));
+            }
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                sb.append(line);
+            }
+
+            // 종료
+            rd.close();
+            conn.disconnect();
+
+            // 결과 출력
+            String str_result = sb.toString();
+            log.info("HTTPHouse 결과 : " + str_result);
+            
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
         }
 
     }

--- a/src/main/resources/mappers/HouseMapper.xml
+++ b/src/main/resources/mappers/HouseMapper.xml
@@ -14,13 +14,44 @@
     </select>
 
     <!-- 사용자 index id로 농장 아이디, 농장 백엔드 주소 받아오기 -->
-    <select id="read_back_url"
+    <select id="read_back_url_list"
         parameterType="java.lang.Integer"
         resultType="com.smartfarm.chameleon.domain.house.dto.UserHouseDTO">
 
         SELECT  id, house_id, house_name, house_back_url
         FROM    house
         WHERE   id=#{id}
+
+    </select>
+
+    <!-- 사용자 index id로 사용자가 보유한 농장 이름 리스트 반환 -->
+    <select id="read_house_name_list"
+        parameterType="java.lang.Integer"
+        resultType="com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO">
+
+        SELECT  house_id, house_name
+        FROM    house
+        WHERE   id=#{id} 
+
+    </select>
+
+    <!-- 농장 아이디로 농장 이름 변경 -->
+    <update id="update_house_name"
+        parameterType="com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO">
+
+        UPDATE  house
+        SET     house_name = #{house_name}
+        WHERE   house_id = #{house_id}
+
+    </update>
+
+    <!-- 농장 아이디로 농장의 백엔드 주소 가져오기 -->
+    <select id="read_back_url"
+        parameterType="java.lang.Integer">
+
+        SELECT  house_back_url
+        FROM    house
+        WHERE   house_id = #{house_id}
 
     </select>
 


### PR DESCRIPTION
## 개요
농장 이름 리스트 조회와 농장 정보 수정 기능 추가
- 농장 이름 리스트 조회 : 사용자 index id로 사용자가 보유한 농장 이름 리스트 반환

### 농장 정보 수정 
- 아이디로 농장 이름과 키우는 작물 수정
- 사용자에게 농장 아이디, 농장 이름, 키우는 작물 정보를 담은 HouseInfoDTO를 받는다.
- 회사 서버 : 농장 아이디로 농장 이름 변경 / 농장 아이디로 농장의 백엔드 주소 반환한다.
- 농장 서버 : 위의 HouseInfoDTO를 byte 배열로 반환해 사용자의 키우는 작물을 수정한다.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 기상청 정보 조회 기능 추가
