### PR TITLE
✨ 회원가입 기능과 농장 CRUD 기능 추가 & 🐛 HttpHouse Get 요청 결과값 분류와 농장 정보 수정 api 

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
@@ -51,7 +51,7 @@ public class HouseController {
     @PutMapping("/update")
     @Operation(summary = "농장 정보 수정" , description = "농장 아이디로 농장 이름과 키우는 작물 수정하는 API")
     public void update_house_name(@RequestHeader("Authorization") String access_token, @RequestBody HouseInfoDTO houseInfoDto ) {
-        houseService.update_house_name(access_token.substring(7), houseInfoDto );
+        houseService.update_house_name(houseInfoDto );
     }
 
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -48,7 +48,7 @@ public class HouseService {
             String get_url = h.getHouse_back_url() + "/house/info";
 
             // get 요청
-            JSONObject house_result = httpHouse.get_http_connection(get_url).get();
+            JSONObject house_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
 
             // 결과 생성
             HouseInfoDTO info_result = new HouseInfoDTO();
@@ -105,7 +105,7 @@ public class HouseService {
         String get_url = houseMapper.read_back_url(house_id) + "/get_weather_info";
 
         // get 요청
-        JSONObject weather_result = httpHouse.get_http_connection(get_url).get();
+        JSONObject weather_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
 
         log.info(weather_result.toJSONString());
 

--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
 import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
@@ -85,7 +86,8 @@ public class HouseService {
     }
 
     // 농장 아이디로 농장 이름과 키우는 작물 수정
-    public void update_house_name(String access_token, HouseInfoDTO houseInfoDto){
+    @Transactional
+    public void update_house_name(HouseInfoDTO houseInfoDto){
 
         // 농장 아이디로 농장 이름 변경
         houseMapper.update_house_name(houseInfoDto);

--- a/src/main/java/com/smartfarm/chameleon/domain/reservation/api/ReservationController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/reservation/api/ReservationController.java
@@ -1,0 +1,73 @@
+package com.smartfarm.chameleon.domain.reservation.api;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.smartfarm.chameleon.domain.reservation.application.ReservationService;
+import com.smartfarm.chameleon.domain.reservation.dto.ReservationDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequestMapping("/reservation")
+@RestController
+public class ReservationController {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    // 예약 정보 리스트 조회
+    @GetMapping("/list/{house_id}")
+    @Operation(summary = "예약 정보 리스트 조회" , description = "예약 목록을 조회하는 API")
+    public ResponseEntity<List<ReservationDTO>> read_reservation_list(@PathVariable("house_id") int house_id){
+        log.info("Reservation Controller : 예약 정보 리스트 조회");
+        
+        return new ResponseEntity<>(reservationService.read_reservation_list(house_id), HttpStatus.OK);
+
+    }
+    
+    //예약 정보 단일 조회
+    @GetMapping("/{house_id}/{reservation_id}")
+    @Operation(summary = "예약 정보 단일 조회" , description = "단일 예약을 조회하는 API")
+    public ResponseEntity<ReservationDTO> read_reservation(@PathVariable("house_id") int house_id, @PathVariable("reservation_id") Integer reservation_id){
+        log.info("Reservation Controller : 예약 정보 단일 조회");
+        return new ResponseEntity<>(reservationService.read_reservation(house_id, reservation_id), HttpStatus.OK);
+    }
+
+    // 예약 정보 DB에 저장
+    @PostMapping("/insert/{house_id}")
+    @Operation(summary = "예약 정보 입력" , description = "예약 정보를 DB에 저장하는 API")
+    public void create_reservation( @PathVariable("house_id") int house_id, @RequestBody ReservationDTO reservationDTO){
+        log.info("Reservation Controller : 예약 정보 DB에 저장");
+        reservationService.create_reservation(house_id, reservationDTO);
+    }
+    
+    // 예약 정보 업데이트
+    @PutMapping("/update/{house_id}")
+    @Operation(summary = "예약 정보 수정" , description = "예약 정보를 수정하는 API")
+    public void update_reservation( @PathVariable("house_id") int house_id, @RequestBody ReservationDTO reservationDTO){
+        log.info("Reservation Controller : 예약 정보 업데이트");
+        reservationService.update_reservation(house_id, reservationDTO);
+    }
+    
+    // 예약 정보 삭제
+    @DeleteMapping("/delete/{house_id}/{reservation_id}")
+    @Operation(summary = "예약 정보 삭제" , description = "예약 정보를 삭제하는 API")
+    public void delete_reservation(@PathVariable("house_id") int house_id, @PathVariable("reservation_id") int reservation_id){
+        log.info("Reservation Controller : 예약 정보 삭제");
+        reservationService.delete_reservation(house_id, reservation_id);
+    }
+    
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/reservation/application/ReservationService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/reservation/application/ReservationService.java
@@ -1,0 +1,116 @@
+package com.smartfarm.chameleon.domain.reservation.application;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
+import com.smartfarm.chameleon.domain.reservation.dto.ReservationDTO;
+import com.smartfarm.chameleon.global.toHouse.HttpHouse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class ReservationService {
+
+    @Autowired
+    private HouseMapper houseMapper;
+
+
+    @Autowired
+    private HttpHouse httpHouse;
+
+    // 예약 정보 리스트 조회
+    public List<ReservationDTO> read_reservation_list(int house_id){
+
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String get_url = houseMapper.read_back_url(house_id) + "/reservation/list";
+
+        // get 요청
+        JSONArray res_result = (JSONArray) httpHouse.get_http_connection(get_url).get();
+
+        // 결과를 담을 List
+        List<ReservationDTO> result = new ArrayList<>();
+
+        // List 처리
+        for(Object o : res_result){
+
+            // List 안의 요소를 JsonObject로 변환
+            JSONObject jsonObject = (JSONObject) o;
+
+            ReservationDTO reservationDTO = new ReservationDTO();
+            reservationDTO.setReservation_id(Integer.parseInt(jsonObject.get("reservation_id").toString()));
+            reservationDTO.setReservation_hour(jsonObject.get("reservation_hour").toString());
+            reservationDTO.setReservation_min(jsonObject.get("reservation_min").toString());
+            reservationDTO.setReservation_day(Integer.parseInt(jsonObject.get("reservation_day").toString()));
+        
+            result.add(reservationDTO);
+        }
+
+        // 결과 출력
+        for(ReservationDTO r : result){
+            log.info(r.toString());
+        }
+
+        return result;
+
+    }
+
+    // 예약 정보 단일 조회
+    public ReservationDTO read_reservation(int house_id, int reservation_id){
+
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String get_url = houseMapper.read_back_url(house_id) + "/reservation/" + reservation_id;
+
+        // get 요청
+        JSONObject res_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
+       
+        // 결과 생성
+        ReservationDTO result = new ReservationDTO();
+        result.setReservation_id(Integer.parseInt(res_result.get("reservation_id").toString()));
+        result.setReservation_hour(res_result.get("reservation_hour").toString());
+        result.setReservation_min(res_result.get("reservation_min").toString());
+        result.setReservation_day(Integer.parseInt(res_result.get("reservation_day").toString()));
+    
+        return result;
+    }
+
+    // 예약 정보 DB에 저장
+    public void create_reservation(int house_id, ReservationDTO reservationDTO){
+        
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String post_url = houseMapper.read_back_url(house_id) + "/reservation/insert"; 
+
+        // post 요청
+        httpHouse.post_http_connection(post_url, reservationDTO);
+
+    }
+
+    // 예약 정보 업데이트
+    public void update_reservation(int house_id, ReservationDTO reservationDTO){
+        
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String put_url = houseMapper.read_back_url(house_id) + "/reservation/update"; 
+
+        // post 요청
+        httpHouse.put_http_connection(put_url, reservationDTO);
+
+    }
+
+    // 예약 정보 삭제
+    public void delete_reservation(int house_id, int reservation_id){
+
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String del_url = houseMapper.read_back_url(house_id) + "/reservation/delete/" + reservation_id;
+
+        // del 요청
+        httpHouse.delete_http_connection(del_url);
+        
+    }
+    
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/reservation/dto/ReservationDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/reservation/dto/ReservationDTO.java
@@ -1,0 +1,20 @@
+package com.smartfarm.chameleon.domain.reservation.dto;
+
+import lombok.Data;
+
+@Data
+public class ReservationDTO {
+
+    // 예약 번호
+    private int reservation_id;
+    
+    // 예약 시
+    private String reservation_hour;
+    
+    // 예약 분
+    private String reservation_min;
+
+    // 예약 요일
+    private int reservation_day;
+    
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/user/api/UserController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/user/api/UserController.java
@@ -3,6 +3,8 @@ package com.smartfarm.chameleon.domain.user.api;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.smartfarm.chameleon.domain.house.application.HouseService;
+import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
 import com.smartfarm.chameleon.domain.login.dto.UserDTO;
 import com.smartfarm.chameleon.domain.user.application.UserService;
 
@@ -14,10 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-
 
 
 @Slf4j
@@ -28,6 +30,9 @@ public class UserController {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private HouseService houseService;
 
     @GetMapping("/info")
     @Operation(summary = "사용자 정보 반환" , description = "이름, 관심 작물, 아이디 정보를 반환하는 API")
@@ -46,6 +51,18 @@ public class UserController {
 
         userService.update_user(access_token.substring(7), userDTO);
     }
+
+    @PostMapping("/serial")
+    @Operation(summary = "시리얼 번호 확인" , description = "시리얼 번호가 올바른지 확인하고 house_id를 반환하는 API")
+    public ResponseEntity<Integer> validate_serial(@RequestBody String serial) {
+        return new ResponseEntity<>(userService.validate_serial(serial),HttpStatus.OK);
+    }
+
+    @PutMapping("/sign_up")
+    public void putMethodName(@RequestBody HouseInfoDTO houseInfoDto) {
+        houseService.update_house_name(houseInfoDto);
+    }
+    
     
     
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/user/application/UserService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/user/application/UserService.java
@@ -47,4 +47,13 @@ public class UserService {
         userMapper.update_user(userDTO);
     }
     
+    /**
+     * 사용자가 입력한 serial번호를 받아서 해당하는 농장이 있는지 확인
+     * 
+     * @param serial
+     * @return : 해당하는 농장 아이디
+     */
+    public int validate_serial(String serial){
+        return userMapper.validate_serial(serial);
+    }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/user/dao/UserMapper.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/user/dao/UserMapper.java
@@ -12,5 +12,8 @@ public interface UserMapper {
 
     // 사용자 이름, 관심 작물 수정
     public void update_user(UserDTO userDTO);
+
+    // 시리얼 번호 확인 후 house_id 반환
+    public int validate_serial(String serial);
     
 }

--- a/src/main/java/com/smartfarm/chameleon/global/config/SecurityConfig.java
+++ b/src/main/java/com/smartfarm/chameleon/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())       // csrf 보안을 사용 X
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/login").permitAll() // 로그인 API는 인증 없이 접근 가능
+                    .requestMatchers("/login", "/user/serial", "/user/sign_up").permitAll() // 로그인 API는 인증 없이 접근 가능
                     .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService, redisService), 

--- a/src/main/java/com/smartfarm/chameleon/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/smartfarm/chameleon/global/filter/JwtAuthenticationFilter.java
@@ -41,8 +41,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.info("filter 거치는 중입니다.");
         log.info("Received request for URI: {}", request.getRequestURI());
 
-        // login api라면 filter를 수행하지 않고 넘김
-        if ("/login".equals(request.getRequestURI())) {
+        // login 또는 회원가입이라면 filter를 수행하지 않고 넘김
+        if ("/login".equals(request.getRequestURI()) || "/user/serial".equals(request.getRequestURI())
+                || "/user/sign_up".equals(request.getRequestURI())) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/smartfarm/chameleon/global/toHouse/HttpHouse.java
+++ b/src/main/java/com/smartfarm/chameleon/global/toHouse/HttpHouse.java
@@ -7,6 +7,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Optional;
 
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.springframework.stereotype.Component;
@@ -26,7 +27,7 @@ public class HttpHouse {
      * @param get_url
      * @return JsonObject
      */
-    public Optional<JSONObject> get_http_connection(String get_url){
+    public Optional<?> get_http_connection(String get_url){
 
         try {
             
@@ -57,13 +58,26 @@ public class HttpHouse {
             String str_result = sb.toString();
             log.info("HTTPHouse 결과 : " + str_result);
 
-            // json parser를 통해 JsonObject로 변환
+            // json parser를 통해 Object로 변환
             JSONParser jsonParser = new JSONParser();
-            JSONObject result = (JSONObject) jsonParser.parse(str_result);
+            Object obj_result = jsonParser.parse(str_result);
 
-            log.info("Json 객체 변환 : " + result.toString());
+            // 반환값이 JsonObject인지 JsonArray형태인지 확인 후 각각 변환
+            if (obj_result instanceof JSONObject) {
+                
+                JSONObject result = (JSONObject) obj_result;
 
-            return Optional.ofNullable(result);
+                log.info("Json 객체 변환 : " + result.toString());
+
+                return Optional.ofNullable(result);
+            } else {
+
+                JSONArray result = (JSONArray) obj_result;
+
+                log.info("Json 리스트 변환 : " + result.toString());
+
+                return Optional.ofNullable(result);
+            }
 
         } catch (Exception e) {
             log.error(e.getMessage(), e);
@@ -72,6 +86,65 @@ public class HttpHouse {
 
     }
 
+    /**
+     * Post Http Connection
+     * 
+     * @param post_url
+     * @param post_data : 입력할 데이터
+     */
+    public void post_http_connection(String post_url, Object post_data){
+
+        try {
+
+            // connection 생성
+            URL url = new URL(post_url);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            conn.setDoOutput(true);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            try (DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+                out.write(objectMapper.writeValueAsString(post_data).getBytes("UTF-8"));
+                out.flush();
+            }
+
+            // 결과값 받아오기
+            BufferedReader rd;
+            if(conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream(), "UTF-8"));
+            }
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                sb.append(line);
+            }
+
+            // 종료
+            rd.close();
+            conn.disconnect();
+
+            // 결과 출력
+            String str_result = sb.toString();
+            log.info("HTTPHouse 결과 : " + str_result);
+            
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+
+
+    }
+
+    /**
+     * Put Http Connection
+     * header의 setDoOutput설정을 true로 설정해 값을 전달할 수 있게 설정
+     * Java의 객체를 OutputStream으로 변환 후 전달
+     * 
+     * @param put_url
+     * @param put_data : 수정할 데이터
+     */
     public void put_http_connection(String put_url, Object put_data){
 
         try {
@@ -85,7 +158,6 @@ public class HttpHouse {
 
             ObjectMapper objectMapper = new ObjectMapper();
             try (DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
-                // out.writeBytes(objectMapper.writeValueAsString(put_data));
                 out.write(objectMapper.writeValueAsString(put_data).getBytes("UTF-8"));
                 out.flush();
             }
@@ -111,6 +183,50 @@ public class HttpHouse {
             String str_result = sb.toString();
             log.info("HTTPHouse 결과 : " + str_result);
             
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+
+    }
+
+
+    /**
+     * Delete Http Connection
+     * 
+     * @param del_url
+     */
+    public void delete_http_connection(String del_url){
+
+        try {
+            
+            // connection 생성
+            URL url = new URL(del_url);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("DELETE");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            // 결과값 받아오기
+            BufferedReader rd;
+            if(conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream(), "UTF-8"));
+            }
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                sb.append(line);
+            }
+
+            // 종료
+            rd.close();
+            conn.disconnect();
+
+            // 결과 출력
+            String str_result = sb.toString();
+            log.info("HTTPHouse 결과 : " + str_result);
+
+
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -25,4 +25,14 @@
 
     </update>
 
+    <!-- 시리얼 번호 확인 후 house_id 반환 -->
+    <select id="validate_serial"
+        resultType="java.lang.Integer" >
+
+        SELECT  house_id
+        FROM    house
+        WHERE   house_serial=#{serial}
+
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 개요

### 회원가입
- serial 번호를 받은 후 매핑되는 농장 아이디를 반환
- serial 번호 인증 후 농장 이름, 키우는 작물을 입력받는다. (메서드는 기존의 농장 정보 수정 메서드를 사용)
- SecurityConfig와 Filter에서 `/user/serial`, `/user/sign_up`은 token검증을 제외
- 이 과정에서 농장 정보 수정 메서드 수정
    - 불필요한 토큰 전달 제외
    - 회사 서버의 농장 이름 수정과 농장 서버의 키우는 작물 수정 요청을 @Transactional 어노테이션으로 묶음

### 농장 CRUD
- 농장 CRUD 기능 추가
- 이 과정에서 HttpHouse Get Connection에서 결과값을 JsonArray와 JsonObject로 분류

## PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- PLC와의 연결을 통한 기기 제어
- PLC에서 수집한 온도 데이터 반환
- 스케줄러를 활용한 평균 데이터 저장
