### PR TITLE
✨ 농장 온도 데이터 조회 기능 구현

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
@@ -1,0 +1,33 @@
+package com.smartfarm.chameleon.domain.house_status.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.smartfarm.chameleon.domain.house_status.application.HouseStatusService;
+import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(name = "농장 상태 확인 API", description = "농장의 각종 상태 데이터 반환")
+@RestController
+@RequestMapping("/house_status")
+public class HouseStatusController {
+
+    @Autowired
+    private HouseStatusService houseStatusService;
+
+    @GetMapping("/tem_info/{house_id}")
+    @Operation(summary = "농장 온도 데이터 조회", description = "농장의 가장 최근 측정 온도값과 기상청의 데이터, 가장 최근 3시간의 평균 온도 데이터를 함께 반환")
+    public ResponseEntity<TemDTO> get_tem_data(@RequestHeader("Authorization") String access_token, @PathVariable("house_id") int house_id) {
+        return new ResponseEntity<>(houseStatusService.get_tem_data(house_id), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
@@ -1,0 +1,72 @@
+package com.smartfarm.chameleon.domain.house_status.application;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
+import com.smartfarm.chameleon.domain.house_status.dto.TemAvgDTO;
+import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
+import com.smartfarm.chameleon.global.toHouse.HttpHouse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class HouseStatusService {
+
+    @Autowired
+    private HouseMapper houseMapper;
+    
+    @Autowired
+    private HttpHouse httpHouse;
+
+    // 가장 최근에 저장된 온도 데이터와 기상청의 데이터
+    // 가장 최근 3시간의 평균 온도 데이터 리스트를 함께 반환
+    public TemDTO get_tem_data(int house_id){
+
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String get_url = houseMapper.read_back_url(house_id) + "/house_status/tem_info";
+
+        // get 요청
+        JSONObject tem_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
+        
+        // 반환할 3시간의 평균 온도 데이터 리스트를 담을 List
+        List<TemAvgDTO> list = new ArrayList<>();
+
+        // 결괏값에서 List 가져오기
+        JSONArray tem_list = (JSONArray) tem_result.get("avg_list");
+
+        // List 처리
+        for(Object o : tem_list){
+
+            // List 안의 요소를 JsonObject로 변환
+            JSONObject jsonObject = (JSONObject) o;
+
+            TemAvgDTO temAvgDTO = new TemAvgDTO();
+            temAvgDTO.setTem_avg_id(Integer.parseInt(jsonObject.get("tem_avg_id").toString()));
+            temAvgDTO.setTem_avg_fin_time(jsonObject.get("tem_avg_fin_time").toString());
+            temAvgDTO.setTem_avg_data(Integer.parseInt(jsonObject.get("tem_avg_data").toString()));
+
+            list.add(temAvgDTO);
+        }
+
+        // 결과 생성
+        TemDTO result = new TemDTO();
+        result.setTem_id(Integer.parseInt(tem_result.get("tem_id").toString()));
+        result.setTem_day_time(tem_result.get("tem_day_time").toString());
+        result.setTem_data(Integer.parseInt(tem_result.get("tem_data").toString()));
+        result.setWeather_tem(Integer.parseInt(tem_result.get("weather_tem").toString()));
+        result.setAvg_list(list);
+
+        // 결과 출력
+        log.info("결과 출력 : " + result.toString());
+
+        return result;
+
+    }
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/TemAvgDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/TemAvgDTO.java
@@ -1,0 +1,20 @@
+package com.smartfarm.chameleon.domain.house_status.dto;
+
+import lombok.Data;
+
+@Data
+public class TemAvgDTO {
+
+    // 평균 온도 테이블 id
+    private int tem_avg_id;
+
+    // 평균 온도 마지막 측정시간
+    private String tem_avg_fin_time;
+
+    // 평균 온도 데이터
+    private int tem_avg_data;
+
+    // 외부 평균 데이터 - TBD
+    private int tem_outside;
+    
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/TemDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/TemDTO.java
@@ -1,0 +1,24 @@
+package com.smartfarm.chameleon.domain.house_status.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class TemDTO {
+
+    // 온도 아이디
+    private int tem_id;
+
+    // 온도 측정 일시
+    private String tem_day_time;
+
+    // 온도 데이터
+    private int tem_data;
+
+    // 기상청의 온도 데이터
+    private int weather_tem;
+
+    // 3시간 평균 온도 리스트
+    private List<TemAvgDTO> avg_list;
+}


### PR DESCRIPTION
## 개요
농장 온도 데이터 조회 기능 구현
- 농장의 가장 최근 측정 온도값과 해당 시간의 기상청 온도 데이터, 가장 최근 3시간의 평균 온도 데이터를 함께 반환
- HouseStatusService : 결과값을 2번 처리 → TemDTO 생성과 List<TemAvgDTO> 생성 후 TemDTO에 저장
- TemAvgDTO : 평균 온도 데이터를 담을 DTO 
- TemDTO : 반환용으로 tem 테이블의 온도 데이터와 기상청 온도 데이터, 평균 리스트를 담을 DTO

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 모터 요청 API 구현
