### PR TITLE
✨ cache 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ repositories {
 
 dependencies {
 
+	// spring boot cache
+	implementation 'org.springframework.boot:spring-boot-stater-cache'
+
 	// json parser
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
@@ -59,4 +62,8 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-parameters'
 }

--- a/src/main/java/com/smartfarm/chameleon/ChameleonApplication.java
+++ b/src/main/java/com/smartfarm/chameleon/ChameleonApplication.java
@@ -3,8 +3,10 @@ package com.smartfarm.chameleon;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 @MapperScan("com.smartfarm.chameleon.domain.*.dao")
 public class ChameleonApplication {
 

--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,7 +103,12 @@ public class HouseService {
     }
 
     // 농장 아이디로 농장의 기상청 데이터 온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 받아옴
+    @Cacheable(value = "weather", key = "#p0")
     public HouseWeatherDTO read_weather_info(int house_id){
+
+        // delete_cache();
+
+        log.info("read_weather_info 메서드 실행");
 
         // 농장 아이디로 농장의 백엔드 주소 가져오기
         String get_url = houseMapper.read_back_url(house_id) + "/get_weather_info";
@@ -120,5 +127,10 @@ public class HouseService {
 
         return houseWeatherDTO;
     }
+
+    // 기상청 데이터의 경우 시간이 지나면 기존 데이터는 쓸모가 없으므로
+    // 새로운 캐시가 저장될 경우 기존 캐시를 지운다.
+    @CacheEvict(value = "weather", allEntries = true )
+    public void delete_cache(){};
 
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house/dto/HouseWeatherDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dto/HouseWeatherDTO.java
@@ -1,9 +1,11 @@
 package com.smartfarm.chameleon.domain.house.dto;
 
+import java.io.Serializable;
+
 import lombok.Data;
 
 @Data
-public class HouseWeatherDTO {
+public class HouseWeatherDTO implements Serializable {
 
     // 습도
     private String weather_hum;


### PR DESCRIPTION
## 개요
기상청 데이터 조회 API 캐싱 기능 추가
- HouseWeatherDTO : Redis에 저장하기 위한 `implement Serializable`
- ChameleonApplication : `@EnableCaching` 어노테이션 추가
- HouseService : `@Cacheable(value = "weather", key = "#p0")` 추가
- build.gradle : `implementation 'org.springframework.boot:spring-boot-stater-cache'`

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 캐시 유효기간 설정
