### PR TITLE
✨ 캐싱 기능 확장 & 🐛 logback.xml 수정

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -33,6 +33,7 @@ public class HouseService {
     private HttpHouse httpHouse;
     
     // 농장 정보 조회
+    @Cacheable(value = "read_house_info")
     public List<HouseInfoDTO> read_house(String access_token){
 
         // 사용자 아이디
@@ -77,6 +78,7 @@ public class HouseService {
     }
 
     // 사용자 index id로 사용자가 보유한 농장 이름 리스트 반환
+    @Cacheable(value = "read_house_name_list")
     public List<HouseInfoDTO> read_house_name_list(String access_token){
 
         // 사용자 아이디
@@ -88,6 +90,7 @@ public class HouseService {
     }
 
     // 농장 아이디로 농장 이름과 키우는 작물 수정
+    @CacheEvict(value = {"read_house_name_list", "read_house_info"})
     @Transactional
     public void update_house_name(HouseInfoDTO houseInfoDto){
 
@@ -103,7 +106,7 @@ public class HouseService {
     }
 
     // 농장 아이디로 농장의 기상청 데이터 온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 받아옴
-    @Cacheable(value = "weather", key ="#p0 + #p1")
+    @Cacheable(value = "read_weather_info", key ="#p0 + #p1")
     public HouseWeatherDTO read_weather_info(int house_id, String cur_time){
 
         // delete_cache();
@@ -127,10 +130,4 @@ public class HouseService {
 
         return houseWeatherDTO;
     }
-
-    // 기상청 데이터의 경우 시간이 지나면 기존 데이터는 쓸모가 없으므로
-    // 새로운 캐시가 저장될 경우 기존 캐시를 지운다.
-    @CacheEvict(value = "weather", allEntries = true )
-    public void delete_cache(){};
-
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
@@ -27,6 +28,7 @@ public class HouseStatusService {
 
     // 가장 최근에 저장된 온도 데이터와 기상청의 데이터
     // 가장 최근 3시간의 평균 온도 데이터 리스트를 함께 반환
+    @Cacheable(value = "get_tem_data")
     public TemDTO get_tem_data(int house_id){
 
         // 농장 아이디로 농장의 백엔드 주소 가져오기

--- a/src/main/java/com/smartfarm/chameleon/global/config/CacheConfig.java
+++ b/src/main/java/com/smartfarm/chameleon/global/config/CacheConfig.java
@@ -22,15 +22,17 @@ public class CacheConfig {
         // 기본 configuration 생성
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                                             .disableCachingNullValues()
-                                            .entryTtl(Duration.ofDays(1))
+                                            .entryTtl(Duration.ofMinutes(60))
                                             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
 
         // 특정 캐시들의 configuration을 저장할 HashMap
         HashMap<String, RedisCacheConfiguration> configMap = new HashMap<>();
 
-        // weather 캐시 configuration 설정
-        configMap.put("weather", RedisCacheConfiguration.defaultCacheConfig()
-                                        .entryTtl(Duration.ofMinutes(60)));
+        // read_house_info 캐시 configuration 설정
+        configMap.put("read_house_info", RedisCacheConfiguration.defaultCacheConfig()
+                                        .entryTtl(Duration.ofDays(1)));
+        configMap.put("read_house_name_list", RedisCacheConfiguration.defaultCacheConfig()
+                                        .entryTtl(Duration.ofDays(1)));                                
 
 
        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory).cacheDefaults(config)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,7 +6,17 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+              <pattern>%d{yyyyMMdd HH:mm:ss.SSS} [%thread] %-3level %logger{5} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="LOGSTASH"/>
+    </root>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
## 개요
 캐싱 기능 확장 &  logback.xml 수정
- HouseService
	- read_house_info 캐시 설정 : 농장 정보(농장 이름, 기르는 작물, 주소) 조회
	- read_house_name_list 캐시 설정 : 사용자 보유한 농장 이름 리스트 
	- read_house_info, read_house_name_list 캐시 삭제 : 농장 이름이 수정되면 기존의 캐시 삭제
	- read_weather_info 캐시 설정 : 기상청 온도, 습도, 풍속, 하늘 상태, 강수 상태 정보 조회
- HouseStatusService : get_tem_data 캐시 설정(온도 데이터, 기상청 온도 데이터, 3시간 평균 온도 데이터 리스트 반환 API)
- CacheConfig : 기본 캐시 TTL 1시간으로 설정 / 농장 정보, 농장 이름 리스트만 TTL 하루로 설정
- logback.xml : logstash에 전달하는 동시에 프로젝트의 terminal에도 로그가 뜨게 설정

## PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
Dockerfile과 Docker-compose.yaml 작성
