### PR TITLE
🐛 jar문제 해결과  jdk arm 17버전으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM arm64v8/openjdk:17-ea-16-jdk
 
 # 외부 환경요소 : jar이 위치할 공간을 지정
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar

--- a/build.gradle
+++ b/build.gradle
@@ -52,21 +52,21 @@ dependencies {
 	implementation 'org.apache.commons:commons-compress:1.26.2'
 
 	implementation 'org.springframework.boot:spring-boot-starter'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-web-services'
 	implementation 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	implementation 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+	implementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 }
 
 bootJar {
-	mainClass = 'com.smartfarm.ChameleonApplication'
+	mainClass = 'com.smartfarm.chameleon.ChameleonApplication'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 개요
jar문제 해결과  jdk arm 17버전으로 변경
- main클래스를 찾을 수 없던 문제 : build.gradle의 bootJar항목에서 mainClass 항목에 application의 경로를 잘못 지정해서 발생했던 오류로 경로를 제대로 입력해 해결하였다.
- java arm버전 오류 : docker hub에서 arm64전용의 java 17버전을 찾아 Dockerfile의 FROM항목을 변경해 해결하였다.

## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 수동 배포 완료
