### PR TITLE
🎨 농장 기상청 데이터 API 이동

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/api/HouseController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.smartfarm.chameleon.domain.house.application.HouseService;
 import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
-import com.smartfarm.chameleon.domain.house.dto.HouseWeatherDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,17 +43,6 @@ public class HouseController {
     @Operation(summary = "농장 이름 리스트 반환" , description = "농장 이름 리스트를 반환하는 API")
     public ResponseEntity<List<HouseInfoDTO>> read_house_name_list(@RequestHeader("Authorization") String access_token) {
         return new ResponseEntity<>(houseService.read_house_name_list(access_token.substring(7)), HttpStatus.OK);
-    }
-
-    @GetMapping("/get_weather_info/{house_id}")
-    @Operation(summary = "농장 기상청 데이터 반환" , description = "온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 반환하는 API")
-    public ResponseEntity<HouseWeatherDTO> read_weather_info(@RequestHeader("Authorization") String access_token, @PathVariable("house_id") int house_id) {
-        
-        // 현재 시각을 hh 형식으로 변환
-        LocalDateTime now = LocalDateTime.now();
-        String cur_time = now.format(DateTimeFormatter.ofPattern("HH"));
-
-        return new ResponseEntity<>(houseService.read_weather_info(house_id, cur_time), HttpStatus.OK);
     }
     
     @PutMapping("/update")

--- a/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/application/HouseService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
 import com.smartfarm.chameleon.domain.house.dto.HouseInfoDTO;
-import com.smartfarm.chameleon.domain.house.dto.HouseWeatherDTO;
 import com.smartfarm.chameleon.domain.house.dto.UserHouseDTO;
 import com.smartfarm.chameleon.global.jwt.JwtTokenProvider;
 import com.smartfarm.chameleon.global.toHouse.HttpHouse;
@@ -105,29 +104,4 @@ public class HouseService {
 
     }
 
-    // 농장 아이디로 농장의 기상청 데이터 온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 받아옴
-    @Cacheable(value = "read_weather_info", key ="#p0 + #p1")
-    public HouseWeatherDTO read_weather_info(int house_id, String cur_time){
-
-        // delete_cache();
-
-        log.info("read_weather_info 메서드 실행");
-
-        // 농장 아이디로 농장의 백엔드 주소 가져오기
-        String get_url = houseMapper.read_back_url(house_id) + "/get_weather_info";
-
-        // get 요청
-        JSONObject weather_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
-
-        log.info(weather_result.toJSONString());
-
-        HouseWeatherDTO houseWeatherDTO = new HouseWeatherDTO();
-        houseWeatherDTO.setWeather_hum(weather_result.get("weatherHum").toString());
-        houseWeatherDTO.setWeather_status(weather_result.get("weatherStatus").toString());
-        houseWeatherDTO.setWeather_preci(weather_result.get("weatherPreci").toString());
-        houseWeatherDTO.setWeather_tem(weather_result.get("weatherTem").toString());
-        houseWeatherDTO.setWeather_wind(weather_result.get("weatherWind").toString());
-
-        return houseWeatherDTO;
-    }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
@@ -1,5 +1,8 @@
 package com.smartfarm.chameleon.domain.house_status.api;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.smartfarm.chameleon.domain.house_status.application.HouseStatusService;
+import com.smartfarm.chameleon.domain.house_status.dto.HouseWeatherDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,5 +33,16 @@ public class HouseStatusController {
     @Operation(summary = "농장 온도 데이터 조회", description = "농장의 가장 최근 측정 온도값과 기상청의 데이터, 가장 최근 3시간의 평균 온도 데이터를 함께 반환")
     public ResponseEntity<TemDTO> get_tem_data(@RequestHeader("Authorization") String access_token, @PathVariable("house_id") int house_id) {
         return new ResponseEntity<>(houseStatusService.get_tem_data(house_id), HttpStatus.OK);
+    }
+
+    @GetMapping("/get_weather_info/{house_id}")
+    @Operation(summary = "농장 기상청 데이터 반환" , description = "온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 반환하는 API")
+    public ResponseEntity<HouseWeatherDTO> read_weather_info(@RequestHeader("Authorization") String access_token, @PathVariable("house_id") int house_id) {
+        
+        // 현재 시각을 hh 형식으로 변환
+        LocalDateTime now = LocalDateTime.now();
+        String cur_time = now.format(DateTimeFormatter.ofPattern("HH"));
+
+        return new ResponseEntity<>(houseStatusService.read_weather_info(house_id, cur_time), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
@@ -10,6 +10,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
+import com.smartfarm.chameleon.domain.house_status.dto.HouseWeatherDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemAvgDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
 import com.smartfarm.chameleon.global.toHouse.HttpHouse;
@@ -70,5 +71,31 @@ public class HouseStatusService {
 
         return result;
 
+    }
+
+    // 농장 아이디로 농장의 기상청 데이터 온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 받아옴
+    @Cacheable(value = "read_weather_info", key ="#p0 + #p1")
+    public HouseWeatherDTO read_weather_info(int house_id, String cur_time){
+
+        // delete_cache();
+
+        log.info("read_weather_info 메서드 실행");
+
+        // 농장 아이디로 농장의 백엔드 주소 가져오기
+        String get_url = houseMapper.read_back_url(house_id) + "/get_weather_info";
+
+        // get 요청
+        JSONObject weather_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
+
+        log.info(weather_result.toJSONString());
+
+        HouseWeatherDTO houseWeatherDTO = new HouseWeatherDTO();
+        houseWeatherDTO.setWeather_hum(weather_result.get("weatherHum").toString());
+        houseWeatherDTO.setWeather_status(weather_result.get("weatherStatus").toString());
+        houseWeatherDTO.setWeather_preci(weather_result.get("weatherPreci").toString());
+        houseWeatherDTO.setWeather_tem(weather_result.get("weatherTem").toString());
+        houseWeatherDTO.setWeather_wind(weather_result.get("weatherWind").toString());
+
+        return houseWeatherDTO;
     }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/HouseWeatherDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/HouseWeatherDTO.java
@@ -1,4 +1,4 @@
-package com.smartfarm.chameleon.domain.house.dto;
+package com.smartfarm.chameleon.domain.house_status.dto;
 
 import java.io.Serializable;
 


### PR DESCRIPTION
## 개요
농장 기상청 데이터 API 이동
- HouseWeatherDTO : house의 dto 폴더에서 house_status의 dto 폴더로 이동
- HouseStatusService & HouseStatusController : read_weather_info 메서드 이동
- HouseController, HouseService : 농장 서버에서 기상청 데이터 가져오는 API 삭제

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 기존 사용자 농장 연결 기능 추가
