### PR TITLE
🎨 허용된 URI 중복 해결

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/global/config/SecurityConfig.java
+++ b/src/main/java/com/smartfarm/chameleon/global/config/SecurityConfig.java
@@ -1,6 +1,11 @@
 package com.smartfarm.chameleon.global.config;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -31,21 +36,31 @@ public class SecurityConfig {
     @Autowired
     private RedisService redisService;
 
+    // 완전히 일치해야하는 URI 목록
+    public static final List<String> PUBLIC_URIS_EQUAL = List.of(
+        "/login", "/user/serial", "/user/sign_up"
+    );
+    // 패턴에 맞춰 시작만 일치해도 되는 URI 목록
+    public static final List<String> PUBLIC_URIS_START = List.of(
+        "/swagger-ui/", "/swagger-ui/**",
+        "/api-docs", "/api-docs/**", "/v3/api-docs/**"
+    );
+
 
     @Bean
     public SecurityFilterChain filterChain (HttpSecurity http) throws Exception {
         http
-                .httpBasic( basic -> basic.disable() )  // basic auth 사용 X
+                .httpBasic(basic -> basic.disable())  // basic auth 사용 X
                 .csrf(csrf -> csrf.disable())       // csrf 보안을 사용 X
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/login", "/user/serial", "/user/sign_up",
-                                        "/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**").permitAll() // 로그인 API는 인증 없이 접근 가능
-                    .anyRequest().authenticated() // 나머지는 인증 필요
+                                .requestMatchers(Stream.concat(PUBLIC_URIS_EQUAL.stream(), PUBLIC_URIS_START.stream())
+                                        .toArray(String[]::new)).permitAll() // 로그인 API는 인증 없이 접근 가능
+                                .anyRequest().authenticated() // 나머지는 인증 필요
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService, redisService), 
-                         UsernamePasswordAuthenticationFilter.class)
-                .cors();    // cors 활성화와 동시에 WebConfig 옵션을 사용
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService, redisService),
+                        UsernamePasswordAuthenticationFilter.class)
+                .cors(withDefaults());    // cors 활성화와 동시에 WebConfig 옵션을 사용
         
         return http.build();
     }

--- a/src/main/java/com/smartfarm/chameleon/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/smartfarm/chameleon/global/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.smartfarm.chameleon.global.filter;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -8,6 +9,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.smartfarm.chameleon.domain.login.dto.TokenDTO;
+import com.smartfarm.chameleon.global.config.SecurityConfig;
 import com.smartfarm.chameleon.global.jwt.CustomUserDetailsService;
 import com.smartfarm.chameleon.global.jwt.JwtTokenProvider;
 import com.smartfarm.chameleon.global.redis.RedisService;
@@ -24,6 +26,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
     private final RedisService redisService;
+    public static final List<String> PUBLIC_URIS_EQUAL = SecurityConfig.PUBLIC_URIS_EQUAL;
+    public static final List<String> PUBLIC_URIS_START = SecurityConfig.PUBLIC_URIS_START;
 
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService userDetailsService, RedisService redisService) {
         this.jwtTokenProvider = jwtTokenProvider;
@@ -36,13 +40,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        log.info("filter 거치는 중입니다.");
-        log.info("Received request for URI: {}", request.getRequestURI());
+        log.debug("filter 거치는 중입니다.");
+        log.debug("Received request for URI: {}", request.getRequestURI());
 
         // login 또는 회원가입이라면 filter를 수행하지 않고 넘김
-        if ("/login".equals(request.getRequestURI()) || "/user/serial".equals(request.getRequestURI())
-                || "/user/sign_up".equals(request.getRequestURI()) || request.getRequestURI().startsWith("/swagger-ui/")
-                || request.getRequestURI().startsWith("/api-docs") ) {
+        if (PUBLIC_URIS_EQUAL.contains(request.getRequestURI()) ||
+                PUBLIC_URIS_START.stream().anyMatch( uri -> request.getRequestURI().startsWith(uri)) ) {
+            log.info("안녕2!");
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
## 개요
허용된 URI 중복 해결
- SecurityConfig
    - `PUBLIC_URIS_EQUAL` : **정확히 일치해야하는 URI**
    - `PUBLIC_URIS_START` : **start로 구분할 수 있는 URI**
    - `authorizeHttpRequests`에 String 문자열이 아닌 String List를 Array로 변경해 입력
- JwtAuthenticationFilter
    - `PUBLIC_URIS_EQUAL` : `contains`를 사용해  `PUBLIC_URIS_EQUAL` 안의 항목들과 요청의 URI가 **정확히 일치하는 것이 하나라도 있다면 true를 반환**
    - `PUBLIC_URIS_START` : `.stream().anyMatch`를 사용해 요청의 URI가  `PUBLIC_URIS_START` 안의 항목으로 **시작하는 것이 하나라도 있다면 true를 반환**


## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- Swagger JWT 헤더 등록
