### PR TITLE
✨OPC UA와 MQTT 통신하기 위한 표준화된 로직 구현

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
+
 @Slf4j
 @Tag(name = "농장 상태 확인 API", description = "농장의 각종 상태 데이터 반환")
 @RestController
@@ -47,4 +48,14 @@ public class HouseStatusController {
 
         return new ResponseEntity<>(houseStatusService.read_weather_info(house_id, cur_time), HttpStatus.OK);
     }
+
+    @GetMapping("/get_tem")
+    @Operation(summary = "(MQTT) 농장 온도 데이터 조회" , description = "OPC UA에서 측정한 온도 데이터를 MQTT 메시지로 전달 받는 API")
+    public ResponseEntity<TemDTO> get_mqtt_tem() {
+
+        log.debug("HouseStatusController : MQTT 테스트 API");
+
+        return new ResponseEntity<>(houseStatusService.read_mqtt_tem().get(), HttpStatus.OK);
+    }
+    
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
@@ -2,6 +2,11 @@ package com.smartfarm.chameleon.domain.house_status.application;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -13,6 +18,9 @@ import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
 import com.smartfarm.chameleon.domain.house_status.dto.HouseWeatherDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemAvgDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
+import com.smartfarm.chameleon.domain.mqtt.application.MqttPublisher;
+import com.smartfarm.chameleon.domain.mqtt.dto.MqttPublisherDTO;
+import com.smartfarm.chameleon.global.config.MQTTConfig;
 import com.smartfarm.chameleon.global.toHouse.HttpHouse;
 
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +34,12 @@ public class HouseStatusService {
     
     @Autowired
     private HttpHouse httpHouse;
+
+    @Autowired
+    private MqttPublisher mqttPublisher;
+
+    @Autowired
+    private MQTTConfig mqttConfig;
 
     /**
      * 농장 서버에 요청을 보내 아래의 데이터를 반환
@@ -69,7 +83,7 @@ public class HouseStatusService {
         TemDTO result = new TemDTO();
         result.setTem_id(Integer.parseInt(tem_result.get("tem_id").toString()));
         result.setTem_day_time(tem_result.get("tem_day_time").toString());
-        result.setTem_data(Integer.parseInt(tem_result.get("tem_data").toString()));
+        result.setTem_data(Double.parseDouble(tem_result.get("tem_data").toString()));
         result.setWeather_tem(Integer.parseInt(tem_result.get("weather_tem").toString()));
         result.setAvg_list(list);
 
@@ -109,5 +123,48 @@ public class HouseStatusService {
         houseWeatherDTO.setWeather_wind(weather_result.get("weatherWind").toString());
 
         return houseWeatherDTO;
+    }
+
+    public Optional<TemDTO> read_mqtt_tem() {
+        
+        // CompletableFuture 생성 및 Map에 저장 (반드시 Map에 저장이 먼저 되어야 함, MQTT 속도가 빨라서 null에러가 발생할 수 있음)
+        CompletableFuture<String> future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseStatusService - read_mqtt_tem : Map에 future 추가 완료");
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/device_01/tmp");
+        mqttPublisherDTO.setMsg("get_tmp");
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+        
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - read_mqtt_tem : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            String tem_data = future.get(10, TimeUnit.SECONDS);
+
+            log.debug("HouseStatusService - read_mqtt_tem : 성공적으로 {}를 전달받았습니다.", tem_data);
+
+            TemDTO temDTO = new TemDTO();
+            temDTO.setTem_data(Double.parseDouble(tem_data));
+
+            return Optional.of(temDTO);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - read_mqtt_tem : InterruptedException 에러 발생");
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - read_mqtt_tem : ExecutionException 에러 발생");
+            return Optional.empty();
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - read_mqtt_tem : TimeoutException 에러 발생");
+            return Optional.empty();
+        }
+
     }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/TemDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/TemDTO.java
@@ -14,7 +14,7 @@ public class TemDTO {
     private String tem_day_time;
 
     // 온도 데이터
-    private int tem_data;
+    private double tem_data;
 
     // 기상청의 온도 데이터
     private int weather_tem;

--- a/src/main/java/com/smartfarm/chameleon/domain/mqtt/application/MqttPublisher.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/mqtt/application/MqttPublisher.java
@@ -1,17 +1,12 @@
 package com.smartfarm.chameleon.domain.mqtt.application;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ExecutionException;
-
-import org.eclipse.paho.client.mqttv3.MqttClient;
-import org.eclipse.paho.client.mqttv3.MqttException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.smartfarm.chameleon.domain.mqtt.dto.MqttPublisherDTO;
 
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
@@ -38,32 +33,35 @@ public class MqttPublisher {
     @Autowired
     private MqttClientConnection connection;
 
-    private String topic = "core/topic/tolocal";
-    private String message = "Hello I'm Spring Boot";
+    private String message = "메시지가 발송 불안정, 다시 시도하겠습니다.";
 
     public void sendMessage(MqttPublisherDTO mqttPublisherDTO) {
 
         // mqttPublisherDTO Json 변환
         ObjectMapper objectMapper = new ObjectMapper();
         try {
+
             message = objectMapper.writeValueAsString(mqttPublisherDTO);
             log.debug("MQTT - Json 변환 : " + message);
+
         } catch (JsonProcessingException e) {
             log.debug("MQTT - Json 변환 실패");
         }
 
         // 발행할 MQTT 메시지 설정
-        MqttMessage mqttMessage = new MqttMessage(topic, message.getBytes(StandardCharsets.UTF_8),
+        MqttMessage mqttMessage = new MqttMessage(mqttPublisherDTO.getTopic(), message.getBytes(StandardCharsets.UTF_8),
                     QualityOfService.AT_LEAST_ONCE, false);
         try {
             
             // MQTT 메시지 발행
             connection.publish(mqttMessage).get();
+
         } catch (Exception e) {
-            e.printStackTrace();
+            log.debug("MQTT - 메시지 발행 실패");
         }
 
-        CrtResource.waitForNoResources();
+        // 모든 connect가 해제될 때까지 기다리는 메서드 (절대 주석 해제하지 말 것)
+        // CrtResource.waitForNoResources();
 
     }
 

--- a/src/main/java/com/smartfarm/chameleon/domain/mqtt/dto/MqttPublisherDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/mqtt/dto/MqttPublisherDTO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 public class MqttPublisherDTO {
     
     private String topic;
-    private String message;
+    private String msg;
+    private int request_id;
 
 }

--- a/src/main/java/com/smartfarm/chameleon/global/config/MQTTConfig.java
+++ b/src/main/java/com/smartfarm/chameleon/global/config/MQTTConfig.java
@@ -1,10 +1,22 @@
 package com.smartfarm.chameleon.global.config;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import org.json.simple.parser.JSONParser;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
+
+import com.smartfarm.chameleon.domain.fcm.application.FCMService;
+import com.smartfarm.chameleon.domain.fcm.dto.FCMMessageDTO;
 
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.crt.CRT;
@@ -37,9 +49,18 @@ public class MQTTConfig {
 
     @Value("${mqtt.aws.iot.rootCa-path}")
     private String rootCaPath;  // rootCa 경로
+
+    @Autowired
+    private FCMService fcmService;
     
-    private final String topic = "core/topic/tocloud";
-    private final String message = "Hello I'm Spring Boot";
+    // 구독 topic +/+로 모든 device로부터 MQTT 메시지를 받게 함.
+    private final String topic = "core/topic/tocloud/+/+";
+
+    // 누적된 request 수, Map의 key로 동작한다.
+    private int request_count = 0;
+
+    // CompletableFuture 객체가 저장될 request_list
+    private Map<Integer, CompletableFuture> request_list = new HashMap<Integer, CompletableFuture>();
 
     @Bean
     public MqttClientConnection awsIotMqtt(){
@@ -90,15 +111,50 @@ public class MQTTConfig {
             // 구독
             connection.subscribe(topic, QualityOfService.AT_LEAST_ONCE, (msg) -> {
 
+                // 메시지 UTF-8로 decode
                 String payload = new String(msg.getPayload(), StandardCharsets.UTF_8);
-                log.debug("MQTT - Received: " + payload);
+                log.debug("MQTT - Received: topic : {} , payload : {}", msg.getTopic(), payload);
 
-                // FCMMessageDTO fcmMessageDTO = new FCMMessageDTO();
-                // fcmMessageDTO.setBody(message.toString());
-                // fcmMessageDTO.setUser_id("test");
-                // fcmMessageDTO.setTitle("OPC UA에서 보내셨습니다 ^^");
+                // 메시지 JsonObject로 변환
+                JSONParser jsonParser = new JSONParser();
+                try {
+                    
+                    Object obj_payload = jsonParser.parse(payload);
+                    JSONObject result = (JSONObject) obj_payload;
 
-                // fcmService.send_message(fcmMessageDTO);
+                    if(Objects.isNull(result.get("request_id"))){
+
+                        // request_id가 없다면 OPC UA에서 먼저 보내는 메시지이므로 앱으로 PUSH 알림
+
+                        FCMMessageDTO fcmMessageDTO = new FCMMessageDTO();
+                        fcmMessageDTO.setBody(result.get("value").toString());
+                        fcmMessageDTO.setUser_id("test");
+                        fcmMessageDTO.setTitle("OPC UA에서 보내셨습니다 ^^");
+
+                        fcmService.send_message(fcmMessageDTO);
+
+                    }else{
+
+                        // log.debug("MQTT - request_list 확인 : {}", request_list.values());
+                        
+                        // request_id가 있다면 RESTful API의 응답이므로 해당 RESTful API를 찾아서 응답 반환
+                        CompletableFuture future = request_list.get(Integer.parseInt(result.get("request_id").toString()));
+
+                        if(Objects.nonNull(future)){
+
+                            future.complete(result.get("value").toString());
+                            log.debug("MQTT - Received: CompletableFuture {}번에게 {}를 전달했습니다.", result.get("request_id").toString(), result.get("value").toString());
+                        
+                        }else{
+                            log.debug("MQTT - Received: CompletableFuture가 null입니다.");
+                        }
+          
+                    }
+
+                } catch (ParseException e) {
+                    log.error("MQTTConfig 구독 - " + e);
+                    throw new RuntimeException(e);
+                }
 
             }).get();
 
@@ -109,5 +165,21 @@ public class MQTTConfig {
 
 
     }
+
+    // Map에 request_id와 completableFuture를 지정
+    public void add_future(CompletableFuture completableFuture){
+
+        // request_count를 1 증가시킨 후 Map에 저장
+        request_list.put(++request_count, completableFuture);
+
+        log.debug("MQTT - request_id {}에 completablaFuture 를 저장완료!", request_count);
+    }
+
+    // MQTT 메시지를 보낼 때 request_id를 지정하기 위해 호출
+    public int return_count(){
+        return request_count;
+    }
+
+
 
 }


### PR DESCRIPTION
## 개요
OPC UA와 MQTT 통신하기 위한 표준화된 로직 구현
- MQTTConfig
	- payload를 Json으로 변환
	- request_id의 유무에 따라 push 알림, RESTful API 응답 로직
	- Map에 CompletableFuture를 추가하는 메서드
	- request_count를 반환하는 메서드
- MqttPublisher : CrtResource.waitForNoResources() 주석 처리
- MqttPublisherDTO : OPC UA에 보낼 MQTT 메시지 DTO에 request_id 추가
- TemDTO : tem_data를 int에서 double로 변경
- HouseStatusController :  MQTT 온도 데이터를 전달할 API 추가
- HouseStatusService
	- CompletableFuture<String> future 생성
	- Map에 저장
	- MQTT 메시지 발행
	- CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 배포 테스트
