### PR TITLE
✨ FCM 알림 사용자 식별

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
@@ -22,6 +22,9 @@ public interface HouseMapper {
     // 농장 아이디로 농장의 백엔드 주소 가져오기
     public String read_back_url(int house_id);
 
+    // 농장 아이디로 사용자 아이디 가져오기
+    public String read_user_id(int house_id);
+
     // 사용자의 USER_PK와 HOUSE_ID 연결
     public void add_house(UserHouseDTO userHouseDTO);
 

--- a/src/main/java/com/smartfarm/chameleon/global/config/MQTTConfig.java
+++ b/src/main/java/com/smartfarm/chameleon/global/config/MQTTConfig.java
@@ -17,6 +17,7 @@ import org.json.simple.parser.ParseException;
 
 import com.smartfarm.chameleon.domain.fcm.application.FCMService;
 import com.smartfarm.chameleon.domain.fcm.dto.FCMMessageDTO;
+import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
 
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.crt.CRT;
@@ -52,6 +53,8 @@ public class MQTTConfig {
 
     @Autowired
     private FCMService fcmService;
+    @Autowired
+    private HouseMapper houseMapper;
     
     // 구독 topic +/+로 모든 device로부터 MQTT 메시지를 받게 함.
     private final String topic = "core/topic/tocloud/+/+";
@@ -125,10 +128,14 @@ public class MQTTConfig {
                     if(Objects.isNull(result.get("request_id")) || Integer.parseInt(result.get("request_id").toString()) == 0  ){
 
                         // request_id가 없거나 0이라면 OPC UA에서 먼저 보내는 메시지이므로 앱으로 PUSH 알림
+                        
+                        int house_id = Integer.parseInt(result.get("house_id").toString());
+                        String user_id = houseMapper.read_user_id(house_id);
 
                         FCMMessageDTO fcmMessageDTO = new FCMMessageDTO();
                         fcmMessageDTO.setBody(result.get("value").toString());
-                        fcmMessageDTO.setUser_id("test");
+                        // fcmMessageDTO.setUser_id("test");
+                        fcmMessageDTO.setUser_id(user_id);
                         fcmMessageDTO.setTitle("OPC UA에서 보내셨습니다 ^^");
 
                         log.debug("MQTT - 메시지 발행하겠습니다.");

--- a/src/main/resources/mappers/HouseMapper.xml
+++ b/src/main/resources/mappers/HouseMapper.xml
@@ -45,6 +45,21 @@
 
     </select>
 
+    <!-- 농장 아이디로 사용자 ID 가져오기 (not pk) -->
+    <select id="read_user_id"
+        parameterType="java.lang.Integer"
+        resultType="java.lang.String">
+
+        SELECT  user_id
+        FROM    user
+        WHERE   id = (
+            SELECT  id
+            FROM    house
+            WHERE   house_id = #{house_id}
+        )
+
+    </select>
+
     <!-- USER_PK와 HOUSE_ID 연결 -->
     <update id="add_house"
         parameterType="com.smartfarm.chameleon.domain.house.dto.UserHouseDTO">


### PR DESCRIPTION
## 개요
FCM 알림 사용자 식별
- MQTTConfig : 응답에서 house_id 추출 후 해당 데이터로 user_id 를 얻은 후 fcmMessageDTO에 추가
- HouseMapper.xml / HouseMapper.java : 농장 아이디로 사용자 ID 가져오기 (not pk) 로직 추가

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 농장의 노드마다 mqtt 통신 API 만들기
