### PR TITLE
✨ house_status 상태 확인 메서드 생성

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/api/HouseStatusController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.smartfarm.chameleon.domain.house_status.application.HouseStatusService;
 import com.smartfarm.chameleon.domain.house_status.dto.HouseWeatherDTO;
+import com.smartfarm.chameleon.domain.house_status.dto.StatusDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,7 +42,7 @@ public class HouseStatusController {
 
     @GetMapping("/get_weather_info/{house_id}")
     @Operation(summary = "농장 기상청 데이터 반환" , description = "온도, 습도, 풍속, 하늘 상태, 강수 상태 정보를 반환하는 API")
-    public ResponseEntity<HouseWeatherDTO> read_weather_info(@PathVariable("house_id") int house_id) {
+    public ResponseEntity<HouseWeatherDTO> get_weather_info(@PathVariable("house_id") int house_id) {
         
         log.info("UserController : 농장 기상청 데이터 반환 API");
 
@@ -52,14 +53,33 @@ public class HouseStatusController {
         return new ResponseEntity<>(houseStatusService.read_weather_info(house_id, cur_time), HttpStatus.OK);
     }
 
-    @GetMapping("/get_tem")
-    @Operation(summary = "(MQTT) 농장 온도 데이터 조회" , description = "OPC UA에서 측정한 온도 데이터를 MQTT 메시지로 전달 받는 API")
-    public ResponseEntity<TemDTO> get_mqtt_tem() {
+    @GetMapping("/get_in_tem_info")
+    @Operation(summary = "(MQTT) 농장 내부 온도 데이터 조회" , description = "OPC UA에서 PLC의 내부 온도 데이터를 MQTT 메시지로 전달 받는 API")
+    public ResponseEntity<TemDTO> get_in_tem() {
 
         log.debug("HouseStatusController : MQTT 테스트 API");
 
-        return new ResponseEntity<>(houseStatusService.read_mqtt_tem().get(), HttpStatus.OK);
+        return new ResponseEntity<>(houseStatusService.read_in_tem().get(), HttpStatus.OK);
     }
+
+    @GetMapping("/get_double_sensor_info/{topic}")
+    @Operation(summary = "(MQTT) 농장 센서 데이터 (double) 조회" , description = "OPC UA에서 PLC의 데이터를 MQTT 메시지로 전달 받는 API")
+    public ResponseEntity<StatusDTO> get_double_sensor_info(@PathVariable("topic") String topic) {
+
+        log.debug("HouseStatusController : MQTT 농장 센서 데이터 (double) 조회");
+
+        return new ResponseEntity<>(houseStatusService.read_double_house_status(topic).get(), HttpStatus.OK);
+    }
+
+    @GetMapping("/get_string_sensor_info/{topic}")
+    @Operation(summary = "(MQTT) 농장 센서 데이터 (string) 조회" , description = "OPC UA에서 PLC의 데이터를 MQTT 메시지로 전달 받는 API")
+    public ResponseEntity<StatusDTO> get_string_sensor_info(@PathVariable("topic") String topic) {
+
+        log.debug("HouseStatusController : MQTT 농장 센서 데이터 (string) 조회");
+
+        return new ResponseEntity<>(houseStatusService.read_string_house_status(topic).get(), HttpStatus.OK);
+    }
+
 
     @PostMapping("/mqtt_test")
     public void mqtt_test (@RequestBody String test) {

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/application/HouseStatusService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
 import com.smartfarm.chameleon.domain.house_status.dto.HouseWeatherDTO;
+import com.smartfarm.chameleon.domain.house_status.dto.StatusDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemAvgDTO;
 import com.smartfarm.chameleon.domain.house_status.dto.TemDTO;
 import com.smartfarm.chameleon.domain.mqtt.application.MqttPublisher;
@@ -125,18 +126,25 @@ public class HouseStatusService {
         return houseWeatherDTO;
     }
 
-    public Optional<TemDTO> read_mqtt_tem() {
+    /**
+     * 사용자가 요청한 RESTful API는 CompletableFuture로 잠시 잡아두고
+     * OPC UA에 mqtt 메시지를 보내 내부 온도 데이터를 받아와서
+     * CompletableFuture로 다시 RESTful API에 응답을 보낸다.
+     * 
+     * @return
+     */
+    public Optional<TemDTO> read_in_tem() {
         
         // CompletableFuture 생성 및 Map에 저장 (반드시 Map에 저장이 먼저 되어야 함, MQTT 속도가 빨라서 null에러가 발생할 수 있음)
         CompletableFuture<String> future = new CompletableFuture<String>();
         mqttConfig.add_future(future);
 
-        log.debug("HouseStatusService - read_mqtt_tem : Map에 future 추가 완료");
+        log.debug("HouseStatusService - read_in_tem : Map에 future 추가 완료");
 
         // MQTT 메시지 발행
         MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
-        mqttPublisherDTO.setTopic("core/topic/tolocal/device_01/tmp");
-        mqttPublisherDTO.setMsg("get_tmp");
+        mqttPublisherDTO.setTopic("core/topic/tolocal/device_01/in_tmp");
+        mqttPublisherDTO.setMsg("get_in_tmp");
         mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
         
         mqttPublisher.sendMessage(mqttPublisherDTO);
@@ -167,6 +175,89 @@ public class HouseStatusService {
         }
 
     }
+
+    public Optional<StatusDTO> read_double_house_status(String topic) {
+        
+        // CompletableFuture 생성 및 Map에 저장
+        CompletableFuture<String> future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseStatusService - read_house_status : Map에 future 추가 완료");
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/device_01/" + topic);
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+        
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - read_double_house_status : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            String data = future.get(10, TimeUnit.SECONDS);
+
+            log.debug("HouseStatusService - read_double_house_status : 성공적으로 {}를 전달받았습니다.", data);
+
+            StatusDTO statusDTO = new StatusDTO();
+            statusDTO.setDou_value(Double.parseDouble(data));
+
+            return Optional.of(statusDTO);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - read_double_house_status : InterruptedException 에러 발생");
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - read_double_house_status : ExecutionException 에러 발생");
+            return Optional.empty();
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - read_double_house_status : TimeoutException 에러 발생");
+            return Optional.empty();
+        }
+    }
+
+
+    public Optional<StatusDTO> read_string_house_status(String topic) {
+        
+        // CompletableFuture 생성 및 Map에 저장
+        CompletableFuture<String> future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseStatusService - read_house_status : Map에 future 추가 완료");
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/device_01/" + topic);
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+        
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - read_double_house_status : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            String data = future.get(10, TimeUnit.SECONDS);
+
+            log.debug("HouseStatusService - read_double_house_status : 성공적으로 {}를 전달받았습니다.", data);
+
+            StatusDTO statusDTO = new StatusDTO();
+            statusDTO.setStr_value(data);
+
+            return Optional.of(statusDTO);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - read_double_house_status : InterruptedException 에러 발생");
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - read_double_house_status : ExecutionException 에러 발생");
+            return Optional.empty();
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - read_double_house_status : TimeoutException 에러 발생");
+            return Optional.empty();
+        }
+    }
+
+
 
     // mqtt_test
     public void mqtt_test(String msg){

--- a/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/StatusDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_status/dto/StatusDTO.java
@@ -1,0 +1,11 @@
+package com.smartfarm.chameleon.domain.house_status.dto;
+
+import lombok.Data;
+
+@Data
+public class StatusDTO {
+    
+    private double dou_value;
+    private String str_value;
+
+}


### PR DESCRIPTION
## 개요
house_status 상태 확인 메서드 생성
- StatusDTO : HouseStatus에서 double, String value 항목을 저장
- HouseStatusService : read_double_house_status, read_string_house_status 메서드 생성
	- read_double_house_status : mqtt로 읽어온 데이터를 double 로 반환
	- read_string_house_status : mqtt로 읽어온 데이터를 string 로 반환
- HouseStatusController : (MQTT) 농장 센서 데이터 (double) 조회, (MQTT) 농장 센서 데이터 (string) 조회 API 생성

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- HouseMachine 상태 확인 메서드, ON/OFF 조작 메서드, 값 조작 메서드 생성
