### PR TITLE
✨HouseMachine 상태 확인, 조작 메서드 추가

### DIFF
--- a/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house/dao/HouseMapper.java
@@ -25,6 +25,9 @@ public interface HouseMapper {
     // 농장 아이디로 사용자 아이디 가져오기
     public String read_user_id(int house_id);
 
+    // 농장 아이디로 device_id 가져오기
+    public String read_device_id(int house_id);
+
     // 사용자의 USER_PK와 HOUSE_ID 연결
     public void add_house(UserHouseDTO userHouseDTO);
 

--- a/src/main/java/com/smartfarm/chameleon/domain/house_machine/api/HouseMachineController.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_machine/api/HouseMachineController.java
@@ -7,7 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.smartfarm.chameleon.domain.house_machine.application.HouseMachineService;
-import com.smartfarm.chameleon.domain.house_machine.dto.HouseMachineDTO;
+import com.smartfarm.chameleon.domain.house_machine.dto.MachineSetDTO;
+import com.smartfarm.chameleon.domain.house_machine.dto.MachineStatusDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,18 +31,44 @@ public class HouseMachineController {
 
     @GetMapping("/motor/status/{house_id}")
     @Operation(summary = "모터 상태 반환", description = "모터 상태를 반환하는 API")
-    public ResponseEntity<HouseMachineDTO> get_motor_status(@PathVariable("house_id") int house_id) {
+    public ResponseEntity<MachineStatusDTO> get_motor_status(@PathVariable("house_id") int house_id) {
         log.info("HouseMachineController : 모터 상태 반환 API");
         return new ResponseEntity<>(houseMachineService.get_motor_status(house_id), HttpStatus.OK);
     }
-    
 
     @PostMapping("/motor/on_off/{house_id}")
     @Operation(summary = "모터 동작", description = "status 값에 따라 모터를 ON/OFF 하는 API")
-    public void motor_on_off(@PathVariable("house_id") int house_id, @RequestBody HouseMachineDTO status) {
+    public void motor_on_off(@PathVariable("house_id") int house_id, @RequestBody MachineStatusDTO status) {
         log.info("HouseMachineController : 모터 동작 API");
         houseMachineService.motor_on_off(house_id, status);
     }
+
+    @GetMapping("/{machine_kind}/status/{house_id}")
+    @Operation(summary = "기기 상태 반환", description = "기기 상태를 반환하는 API")
+    public ResponseEntity<MachineStatusDTO> get_machine_status(@PathVariable String machine_kind, @PathVariable int house_id) {
+        log.info("HouseMachineController : 기기 상태 반환 API");
+        return new ResponseEntity<>(houseMachineService.read_machine_status(machine_kind, house_id).get(), HttpStatus.OK);
+    }
+
+    @PostMapping("/{machine_kind}/operate/{house_id}")
+    @Operation(summary = "기기 동작 변경", description = "전달된 boolean 값에 따라 기기를 ON/OFF 하는 API")
+    public void machine_on_off(@PathVariable String machine_kind, @PathVariable int house_id, @RequestBody MachineStatusDTO status) {
+        log.info("HouseMachineController : 기기 동작 API");
+        houseMachineService.machine_on_off(machine_kind, house_id, status);
+    }
+
+    @GetMapping("/{user_set_kind}/user_status/{house_id}")
+    @Operation(summary = "사용자 세팅 반환", description = "사용자 세팅을 반환하는 API")
+    public ResponseEntity<MachineSetDTO> get_user_set_status (@PathVariable String user_set_kind, @PathVariable int house_id) {
+        log.info("HouseMachineController : 사용자 세팅 반환 API");
+        return new ResponseEntity<>(houseMachineService.read_user_set_status(user_set_kind, house_id).get(), HttpStatus.OK);
+    }
     
+    @PostMapping("/{user_set_kind}/user_operate/{house_id}")
+    @Operation(summary = "사용자 세팅 변경", description = "전달된 double 값에 따라 사용자 세팅을 변경하는 API")
+    public void update_user_setting (@PathVariable String user_set_kind, @PathVariable int house_id, @RequestBody MachineSetDTO set_value) {
+        log.info("HouseMachineController : 기기 동작 API");
+        houseMachineService.update_user_setting(user_set_kind, house_id, set_value);
+    }
     
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_machine/application/HouseMachineService.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_machine/application/HouseMachineService.java
@@ -1,11 +1,21 @@
 package com.smartfarm.chameleon.domain.house_machine.application;
 
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.smartfarm.chameleon.domain.house.dao.HouseMapper;
-import com.smartfarm.chameleon.domain.house_machine.dto.HouseMachineDTO;
+import com.smartfarm.chameleon.domain.house_machine.dto.MachineSetDTO;
+import com.smartfarm.chameleon.domain.house_machine.dto.MachineStatusDTO;
+import com.smartfarm.chameleon.domain.mqtt.application.MqttPublisher;
+import com.smartfarm.chameleon.domain.mqtt.dto.MqttPublisherDTO;
+import com.smartfarm.chameleon.global.config.MQTTConfig;
 import com.smartfarm.chameleon.global.toHouse.HttpHouse;
 
 import lombok.extern.slf4j.Slf4j;
@@ -20,13 +30,18 @@ public class HouseMachineService {
     @Autowired
     private HouseMapper houseMapper;
 
+    @Autowired
+    private MQTTConfig mqttConfig;
+    @Autowired
+    private MqttPublisher mqttPublisher;
+
     /**
      * 농장 서버에 모터 상태를 조회 요청을 보내는 메서드
      * 
      * @param house_id
      * @return
      */
-    public HouseMachineDTO get_motor_status(int house_id){
+    public MachineStatusDTO get_motor_status(int house_id){
 
         // 농장 아이디로 농장의 백엔드 주소 가져오기
         String get_url = houseMapper.read_back_url(house_id) + "/house_machine/motor/status";
@@ -35,11 +50,11 @@ public class HouseMachineService {
         JSONObject res_result = (JSONObject) httpHouse.get_http_connection(get_url).get();
 
         // 결과 생성
-        HouseMachineDTO result = new HouseMachineDTO();
-        result.setMotor_status(Boolean.parseBoolean(res_result.get("motor_status").toString()));
+        MachineStatusDTO result = new MachineStatusDTO();
+        result.setValue(Boolean.parseBoolean(res_result.get("motor_status").toString()));
 
         // 결과 출력
-        log.info("get_motor_status - 모터 상태 : " + result.isMotor_status());
+        log.info("get_motor_status - 모터 상태 : " + result.isValue());
 
         return result;
     }
@@ -50,13 +65,191 @@ public class HouseMachineService {
      * @param house_id
      * @param status
      */
-    public void motor_on_off(int house_id, HouseMachineDTO status){
+    public void motor_on_off(int house_id, MachineStatusDTO status){
 
         // 농장 아이디로 농장의 백엔드 주소 가져오기
         String post_url = houseMapper.read_back_url(house_id) + "/house_machine/motor/on_off";
 
         // post 요청 - 모터 on/off
         httpHouse.post_http_connection(post_url, status);
+
+    }
+
+    /**
+     * 농장에 기기의 상태 반환을 요청하는 메서드
+     * 
+     * @param machine_kind : 요청할 기기 종류
+     * @param house_id : device_id를 알아옴
+     * @return : 읽어온 boolean 값을 반환
+     */
+    public Optional<MachineStatusDTO> read_machine_status(String machine_kind, int house_id){
+
+        // CompletableFuture 생성 및 Map에 저장
+        CompletableFuture future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseMachineService - read_machine_status : Map에 future 추가 완료");
+
+        // house_id로 device_id 가져오기
+        String device_id = houseMapper.read_device_id(house_id);
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/" + device_id + "/" + machine_kind);
+        mqttPublisherDTO.setMsg("status");
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - read_machine_status : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            String data = future.get(10, TimeUnit.SECONDS).toString();
+
+            log.debug("HouseStatusService - read_machine_status : 성공적으로 {}를 전달받았습니다.", data);
+
+            MachineStatusDTO result = new MachineStatusDTO();
+            result.setValue(Boolean.parseBoolean(data));
+
+            return Optional.of(result);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - read_machine_status : InterruptedException 에러 발생");
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - read_machine_status : ExecutionException 에러 발생");
+            return Optional.empty();
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - read_machine_status : TimeoutException 에러 발생");
+            return Optional.empty();
+        }
+
+    }
+
+    /**
+     * 
+     * 사용자 요청에 따라 기기의 상태를 변경하는 메서드
+     * 
+     * @param machine_kind : 요청할 기기 종류
+     * @param house_id : device_id를 알아옴
+     * @param status : 사용자가 조작한 boolean 값
+     */
+    public void machine_on_off(String machine_kind, int house_id, MachineStatusDTO status){
+        // CompletableFuture 생성 및 Map에 저장
+        CompletableFuture future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseMachineService - read_machine_status : Map에 future 추가 완료");
+
+        // house_id로 device_id 가져오기
+        String device_id = houseMapper.read_device_id(house_id);
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/" + device_id + "/" + machine_kind);
+        mqttPublisherDTO.setMsg("operate");
+        mqttPublisherDTO.setBool_value(status.isValue());
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - read_machine_status : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            String data = future.get(10, TimeUnit.SECONDS).toString();
+
+            log.debug("HouseStatusService - read_machine_status : 성공적으로 {}를 전달받았습니다.", data);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - read_machine_status : InterruptedException 에러 발생");
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - read_machine_status : ExecutionException 에러 발생");
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - read_machine_status : TimeoutException 에러 발생");
+        }
+    }
+
+    public Optional<MachineSetDTO> read_user_set_status(String machine_kind, int house_id){
+
+        // CompletableFuture 생성 및 Map에 저장
+        CompletableFuture future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseMachineService - read_user_set_status : Map에 future 추가 완료");
+
+        // house_id로 device_id 가져오기
+        String device_id = houseMapper.read_device_id(house_id);
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/" + device_id + "/" + machine_kind);
+        mqttPublisherDTO.setMsg("status");
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - read_user_set_status : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            double data = Double.parseDouble(future.get(10, TimeUnit.SECONDS).toString());
+
+            log.debug("HouseStatusService - read_user_set_status : 성공적으로 {}를 전달받았습니다.", data);
+
+            MachineSetDTO result = new MachineSetDTO();
+            result.setValue(data);
+            
+            return Optional.of(result);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - read_user_set_status : InterruptedException 에러 발생");
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - read_user_set_status : ExecutionException 에러 발생");
+            return Optional.empty();
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - read_user_set_status : TimeoutException 에러 발생");
+            return Optional.empty();
+        }
+
+    }
+    public void update_user_setting (String user_set_kind, int house_id, MachineSetDTO set_value){
+
+        // CompletableFuture 생성 및 Map에 저장
+        CompletableFuture future = new CompletableFuture<String>();
+        mqttConfig.add_future(future);
+
+        log.debug("HouseMachineService - update_user_setting : Map에 future 추가 완료");
+
+        // house_id로 device_id 가져오기
+        String device_id = houseMapper.read_device_id(house_id);
+
+        // MQTT 메시지 발행
+        MqttPublisherDTO mqttPublisherDTO = new MqttPublisherDTO();
+        mqttPublisherDTO.setTopic("core/topic/tolocal/" + device_id + "/" + user_set_kind);
+        mqttPublisherDTO.setMsg("operate");
+        mqttPublisherDTO.setDou_value(set_value.getValue());
+        mqttPublisherDTO.setRequest_id(mqttConfig.return_count());
+
+        mqttPublisher.sendMessage(mqttPublisherDTO);
+
+        log.debug("HouseStatusService - update_user_setting : MQTT 메시지 발행 후 결과 대기 중");
+
+        try {
+            // CompletableFuture 가 complete된 후 결과값을 Double로 변환 후 반환
+            double data = Double.parseDouble(future.get(10, TimeUnit.SECONDS).toString());
+
+            log.debug("HouseStatusService - update_user_setting : 성공적으로 {}를 전달받았습니다.", data);
+
+        } catch (InterruptedException e) {
+            log.error("HouseStatusService - update_user_setting : InterruptedException 에러 발생");
+        } catch (ExecutionException e) {
+            log.error("HouseStatusService - update_user_setting : ExecutionException 에러 발생");
+        } catch (TimeoutException e) {
+            log.error("HouseStatusService - update_user_setting : TimeoutException 에러 발생");
+        }
 
     }
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_machine/dto/MachineSetDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_machine/dto/MachineSetDTO.java
@@ -3,9 +3,8 @@ package com.smartfarm.chameleon.domain.house_machine.dto;
 import lombok.Data;
 
 @Data
-public class HouseMachineDTO {
-
-    // 모터 상태
-    private boolean motor_status;
+public class MachineSetDTO {
     
+    private double value;
+
 }

--- a/src/main/java/com/smartfarm/chameleon/domain/house_machine/dto/MachineStatusDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/house_machine/dto/MachineStatusDTO.java
@@ -1,0 +1,11 @@
+package com.smartfarm.chameleon.domain.house_machine.dto;
+
+import lombok.Data;
+
+@Data
+public class MachineStatusDTO {
+
+    // 기기 상태
+    private boolean value;
+    
+}

--- a/src/main/java/com/smartfarm/chameleon/domain/mqtt/dto/MqttPublisherDTO.java
+++ b/src/main/java/com/smartfarm/chameleon/domain/mqtt/dto/MqttPublisherDTO.java
@@ -5,8 +5,10 @@ import lombok.Data;
 @Data
 public class MqttPublisherDTO {
     
-    private String topic;
-    private String msg;
-    private int request_id;
+    private String  topic;
+    private String  msg;
+    private boolean bool_value;
+    private double  dou_value;
+    private int     request_id;
 
 }

--- a/src/main/resources/mappers/HouseMapper.xml
+++ b/src/main/resources/mappers/HouseMapper.xml
@@ -60,6 +60,17 @@
 
     </select>
 
+    <!-- 농장 아이디로 device_id 가져오기 -->
+    <select id="read_device_id"
+        parameterType="java.lang.Integer"
+        resultType="java.lang.String">
+
+        SELECT  device_id
+        FROM    house
+        WHERE   house_id = #{house_id}
+
+    </select>
+
     <!-- USER_PK와 HOUSE_ID 연결 -->
     <update id="add_house"
         parameterType="com.smartfarm.chameleon.domain.house.dto.UserHouseDTO">


### PR DESCRIPTION
## 개요
HouseMachine 상태 확인, 조작 메서드 추가
- HouseMapper.xml / HouseMapper.java : 농장 아이디로 device_id 가져오는 query 추가
- MqttPublisherDTO : bool_value, dou_value 추가
- MachineStatusDTO : boolean값을 저장하며 기기 상태 확인, ON/OFF 조작 메서드에 사용된다.
- MachineSetDTO : double값을 저장하며 사용자 세팅 상태 확인, 값 변경 메서드에 사용된다.
- HouseMachineDTO : MachineSetDTO 와 MachineStatusDTO 로 대체
- HouseMachineService : 전달된 machine_kind 또는 user_set_kind 와 device_id를 topic에 덧붙혀 MQTT 메시지를 발행한다.
	- 상태 확인 메서드 : `msg`를 **status로 지정**
	- 조작 메서드 : `msg`를 **operate로 지정**, **bool_value 또는 dou_value에 전달된 값 지정**
	- 조작 메서드도 OPC UA로부터 제대로 수행되었는지 확인하는 MQTT 응답을 받는다.
- HouseMachineController : PathVariable로 `house_id`, `machine_kind` 또는 `user_set_kind` 를 입력받고 기기 동작 변경, 사용자 세팅 변경 API라면 boolean, double값이 저장된 DTO를 입력받는다.
	→ **`machine_kind`와 `user_set_kind`에는 구독에 정의된 값이 들어간다.**


## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- user_status 수정 및 구독 규정 정리
